### PR TITLE
Add bozo handling to feedparser.parse

### DIFF
--- a/check_rss.py
+++ b/check_rss.py
@@ -45,6 +45,8 @@ def fetch_feed_last_entry(feed_url):
         output = 'Could not parse URL (%s)' % feed_url
         exitcritical(output, '')
 
+    if myfeed.bozo != 0:
+        exitcritical('Malformed feed: %s' % (myfeed.bozo_exception), '')
     if (myfeed.status != 200):
         exitcritical('Status %s - %s' % (myfeed.status, myfeed.feed.summary), '')
 


### PR DESCRIPTION
If you have a failure to fetch the RSS feed, say, PURELY AS A HYPOTHETICAL, if there's a large company who can't sort out their intermediate certificates and you get an SSL error on the fetch:

Traceback (most recent call last):
  File "/usr/lib64/nagios/plugins/check_rss.py", line 237, in <module>
    result = main(sys.argv)
  File "/usr/lib64/nagios/plugins/check_rss.py", line 134, in main
    last_entry = fetch_feed_last_entry(rssfeed)
  File "/usr/lib64/nagios/plugins/check_rss.py", line 48, in fetch_feed_last_entry
    if (myfeed.status != 200):
  File "/usr/lib/python2.7/site-packages/feedparser.py", line 416, in __getattr__
    raise AttributeError, "object has no attribute '%s'" % key
AttributeError: object has no attribute 'status'

This patch saves you from the traceback and explains the source of the problem.